### PR TITLE
Fix shuffle indicator in info panel

### DIFF
--- a/scripts/shuffle_toggle.lua
+++ b/scripts/shuffle_toggle.lua
@@ -39,6 +39,8 @@ function apply_shuffle()
         mp.commandv("loadfile", playlist[i], "append")
     end
     shuffled = true
+    -- notify other scripts of shuffle state change
+    mp.commandv("script-message", "shuffle_state", "on")
 end
 
 function toggle_shuffle()
@@ -54,6 +56,7 @@ function toggle_shuffle()
         mp.set_property_number("playlist-pos", original_index_map[current_file])
         mp.set_property_number("time-pos", current_position)
         shuffled = false
+        mp.commandv("script-message", "shuffle_state", "off")
     else
         mp.msg.info("Applying shuffle")
         apply_shuffle()

--- a/scripts/toggle-menu.lua
+++ b/scripts/toggle-menu.lua
@@ -470,5 +470,12 @@ mpv.mp.add_key_binding("Ctrl+k", "toggle_menu", Menu.toggle)
 mpv.mp.add_key_binding("j", "playlist_next_custom", Playback.next_video)
 mpv.mp.add_key_binding("k", "playlist_prev_custom", Playback.prev_video)
 
+-- Receive shuffle state updates from other scripts
+mpv.mp.register_script_message("shuffle_state", function(value)
+  mpv.msg.info("Shuffle state message received: " .. tostring(value))
+  State.shuffled = (value == "on" or value == "true" or value == "1")
+  if State.menu_visible then Menu.update() end
+end)
+
 
 -- |   END: toggle-menu.lua


### PR DESCRIPTION
## Summary
- update `toggle-menu.lua` to receive shuffle state via script message
- notify `toggle-menu.lua` from `shuffle_toggle.lua` when shuffle toggles

## Testing
- `luac -p scripts/toggle-menu.lua`
- `luac -p scripts/shuffle_toggle.lua`


------
https://chatgpt.com/codex/tasks/task_e_685561765ca48333bfaac7fc165cb4a7